### PR TITLE
Fix odd behavior in string concatenation

### DIFF
--- a/lib/rex/text/table.rb
+++ b/lib/rex/text/table.rb
@@ -398,7 +398,6 @@ protected
   #
   def pad(chr, buf, colidx, use_cell_pad = true) # :nodoc:
     # Ensure we pad the minimum required amount
-    buf.force_encoding("UTF-16LE")
     max = colprops[colidx]['MaxChar'] || colprops[colidx]['MaxWidth']
     max = colprops[colidx]['MaxWidth'] if max.to_i > colprops[colidx]['MaxWidth'].to_i
     encoding = buf.encoding.name

--- a/lib/rex/text/table.rb
+++ b/lib/rex/text/table.rb
@@ -398,15 +398,15 @@ protected
   #
   def pad(chr, buf, colidx, use_cell_pad = true) # :nodoc:
     # Ensure we pad the minimum required amount
+    buf.force_encoding("UTF-16LE")
     max = colprops[colidx]['MaxChar'] || colprops[colidx]['MaxWidth']
     max = colprops[colidx]['MaxWidth'] if max.to_i > colprops[colidx]['MaxWidth'].to_i
-
     encoding = buf.encoding.name
     if not ["UTF-8", "ASCII-8BIT", "US-ASCII"].include? encoding
-      warn '**WARNING** In file #{__FILE__}::pad : String with unsupported encoding caught!'
+      warn '**WARNING** In file ' << __FILE__ << '::' <<\
+        __method__.to_s << ': String with unsupported encoding caught!'
     end
     utf8_buf = buf.dup.force_encoding("UTF-8")
-
     remainder = max - utf8_buf.length
     remainder = 0 if remainder < 0
     val       = chr * remainder


### PR DESCRIPTION
I still could not get the negative case to print out quite right:

`**WARNING** In file #{__FILE__}::pad : String with unsupported encoding caught!`

Not sure if there's something with the concatenation of the `__File__` value or what.  Please take a look at this; I just took out whitespace and altered the warn string generation.  Please merge with yours if you agree:

`**WARNING** In file /home/bwatters/rapid7/rex-text/lib/rex/text/table.rb::pad: String with unsupported encoding caught!`